### PR TITLE
Prevent mouse clicks from being blocked when the Toy Box is *not* on screen

### DIFF
--- a/ScrollTemplate/AttachedFrameScroll.lua
+++ b/ScrollTemplate/AttachedFrameScroll.lua
@@ -170,7 +170,7 @@ function ListMixin:OnLoad()
 
     CallbackRegistryMixin.OnLoad(self)
     self:SetScript("OnEvent", function(self, event, button)
-        if (event == "CURSOR_CHANGED" and L.AttachedFrame:IsShown()) then
+        if (event == "CURSOR_CHANGED" and L.AttachedFrame:IsVisible()) then
             if (L:CursorHasToy()) then
                 L.ToyJunkie.DragBackdrop:Show()
             end


### PR DESCRIPTION
Issue:

After I move a toy _inside my bags_, all mouse clicks against the world frame are intercepted by ToyJunkie’s DragBackdrop frame (e.g. I can no longer move the toon via right mouse button steering). Note that this happens also when ToyJunkie (or the Toy box) isn’t involved at all, not even visible.

To reproduce:

1. Make sure ToyJunkie is loaded, and no other addons are loaded.
1. Have a toy (any) in your bags.
2. Open the Blizz CollectionsJournal to the Toy Box and close it again (apparently this is necessary to create the DragBackdrop frame).
4. Move the toy in your bags (e.g. from one slot to the next one).
5. Try to move your toon via right mouse button now.
   - **This will fail, because the mouse is intercepted by the DragBackdrop frame.**
6. To unblock your mouse, you have to open and close the Toy Box again.
8. If you move the toy again, the same thing will repeat.

For obvious reasons, this should not happen. ToyJunkie’s DragBackdrop frame should not be shown at all if the ToyBox and ToyJunkie’s list are not open. (The blocked mouse can be quite irritating if you don't know what is going on!)

My fix works for the described situation, but it is a lazy and “weak” fix, because some (minor) issues with the DragBackdrop frame remain:

- When dragging a toy from the Toy Box towards ToyJunkie’s attached list frame but then abandoning the drag via right-click anywhere, the DragBackdrop frame is not hidden as it should be. (It is hidden when I close the Toy Box.)
- When moving a toy inside your bags *while the Toy Box is open*, the DragBackdrop frame still gets shown (and blocks the mouse)

I call these “minor” problems, because the Toy Box and ToyJunkie are involved (open) here, which is not the case for the major problem (showing the DragBackdrop frame when just moving a toy inside the bags *without the Toy Box being open*). 

So, for a really proper fix, I guess the whole show/hide mechanics for the DragBackdrop frame should be revised. E.g. unconditionally hiding the frame on right-click? Registering the CURSOR_CHANGED event only when the attached list is drawn out? But this is beyond the scope of this mini PR 🫠

Oh, and thanks for this nice addon ☺️!

